### PR TITLE
printing response data instead of response object (Temporary Fix)

### DIFF
--- a/src/Samples/Reporting/CoreServices/DownloadReport.cs
+++ b/src/Samples/Reporting/CoreServices/DownloadReport.cs
@@ -31,7 +31,7 @@ namespace Cybersource_rest_samples_dotnet.Samples.Reporting.CoreServices
                 var apiInstance = new ReportDownloadsApi(clientConfig);
 
                 var result = apiInstance.DownloadReportWithHttpInfo(reportDate, reportName, organizationId);
-                Console.WriteLine(result);
+                Console.WriteLine(result.Data.ToString());
 
                 File.WriteAllText(downloadFilePath, CreateXml(result.Data));
                 Console.WriteLine("\nFile downloaded at the below location:");

--- a/src/Samples/Reporting/CoreServices/DownloadReport.cs
+++ b/src/Samples/Reporting/CoreServices/DownloadReport.cs
@@ -31,7 +31,7 @@ namespace Cybersource_rest_samples_dotnet.Samples.Reporting.CoreServices
                 var apiInstance = new ReportDownloadsApi(clientConfig);
 
                 var result = apiInstance.DownloadReportWithHttpInfo(reportDate, reportName, organizationId);
-                Console.WriteLine(result.Data.ToString());
+                Console.WriteLine(result);
 
                 File.WriteAllText(downloadFilePath, CreateXml(result.Data));
                 Console.WriteLine("\nFile downloaded at the below location:");

--- a/src/Samples/Reporting/CoreServices/RetrieveAvailableReports.cs
+++ b/src/Samples/Reporting/CoreServices/RetrieveAvailableReports.cs
@@ -19,7 +19,6 @@ namespace Cybersource_rest_samples_dotnet.Samples.Reporting.CoreServices
                 var apiInstance = new ReportsApi(clientConfig);
 
                 var result = apiInstance.SearchReports(startTime, endTime, timeQueryType, organizationId);
-                Console.WriteLine(result);
             }
             catch (Exception e)
             {


### PR DESCRIPTION
This PR has a dependency on the client SDK PR.

In GetAvailableReports (RetrieveAvailableReports) Sample code, the response is not getting deserialised, due to which the data is coming as blank in the response object.
As a temporary fix, we are removing the print statement of result object.
The response data will be printed as per the fix done in client sdk (in ApiClient file - including print of response body)
In the future release permanent fix will be done by updating the corresponding model file so that deserialisation takes place properly.