### PR TITLE
printing non null (string) data of result object

### DIFF
--- a/src/Samples/Payouts/CoreServices/ProcessPayout.cs
+++ b/src/Samples/Payouts/CoreServices/ProcessPayout.cs
@@ -113,7 +113,7 @@ namespace Cybersource_rest_samples_dotnet.Samples.Payouts.CoreServices
                 var apiInstance = new ProcessAPayoutApi(clientConfig);
 
                 var result = apiInstance.OctCreatePaymentWithHttpInfo(requestObj);
-                Console.WriteLine(result);
+                Console.WriteLine(result.Data);
             }
             catch (Exception e)
             {


### PR DESCRIPTION
This PR has a dependency on client SDK PR.

The client sdk has been modified to return the response object which contains data in 'Data' property.
So in sample code, while printing the response data, need to explicitly print Data property of result object.