### PR TITLE
Commit0228

### DIFF
--- a/src/Samples/Payments/CoreServices/ProcessAuthorizationReversal.cs
+++ b/src/Samples/Payments/CoreServices/ProcessAuthorizationReversal.cs
@@ -14,7 +14,7 @@ namespace Cybersource_rest_samples_dotnet.Samples.Payments.CoreServices
             var clientReferenceInformationObj = new Ptsv2paymentsidreversalsClientReferenceInformation("test_reversal");
             var amount = new Ptsv2paymentsidreversalsOrderInformationLineItems(null, "102.21");
             var amountDetailsObj = new List<Ptsv2paymentsidreversalsOrderInformationLineItems> { amount };
-            var orderInformationObj = new Ptsv2paymentsidreversalsOrderInformation(amountDetailsObj);
+            var orderInformationObj = new Ptsv2paymentsidreversalsOrderInformation(null, amountDetailsObj);
             var requestBody = new AuthReversalRequest(clientReferenceInformationObj, null, null, orderInformationObj);
 
             try

--- a/src/Samples/Payments/CoreServices/ProcessPayment.cs
+++ b/src/Samples/Payments/CoreServices/ProcessPayment.cs
@@ -16,7 +16,6 @@ namespace Cybersource_rest_samples_dotnet.Samples.Payments.CoreServices
 
             var pointOfSaleInformationObj = new Ptsv2paymentsPointOfSaleInformation
             {
-                CardPresent = false,
                 CatLevel = 6,
                 TerminalCapability = 4
             };

--- a/src/Samples/Payouts/CoreServices/ProcessPayout.cs
+++ b/src/Samples/Payouts/CoreServices/ProcessPayout.cs
@@ -10,7 +10,7 @@ namespace Cybersource_rest_samples_dotnet.Samples.Payouts.CoreServices
         {
             var requestObj = new PtsV2PayoutsPostResponse();
 
-            var clientReferenceInformationObj = new PtsV2PaymentsPost201ResponseClientReferenceInformation
+            var clientReferenceInformationObj = new Ptsv2payoutsClientReferenceInformation
             {
                 Code = "33557799"
             };
@@ -112,7 +112,7 @@ namespace Cybersource_rest_samples_dotnet.Samples.Payouts.CoreServices
                 var clientConfig = new CyberSource.Client.Configuration(merchConfigDictObj: configDictionary);
                 var apiInstance = new ProcessAPayoutApi(clientConfig);
 
-                var result = apiInstance.OctCreatePaymentWithHttpInfo(requestObj);
+                var result = apiInstance.OctCreatePayment(requestObj);
                 Console.WriteLine(result);
             }
             catch (Exception e)

--- a/src/Samples/Reporting/CoreServices/CreateAdhocReport.cs
+++ b/src/Samples/Reporting/CoreServices/CreateAdhocReport.cs
@@ -12,7 +12,7 @@ namespace Cybersource_rest_samples_dotnet.Samples.Reporting.CoreServices
         {
             try
             {
-                var requestObj = new RequestBody1
+                var requestObj = new RequestBody
                 {
                     ReportDefinitionName = "TransactionRequestClass",
                     ReportFields = new List<string>()
@@ -21,17 +21,17 @@ namespace Cybersource_rest_samples_dotnet.Samples.Reporting.CoreServices
                         "Request.TransactionDate",
                         "Request.MerchantID"
                     },
-                    ReportMimeType = RequestBody1.ReportMimeTypeEnum.ApplicationXml,
-                    ReportName = "testrest_vter9",
+                    ReportMimeType = RequestBody.ReportMimeTypeEnum.ApplicationXml,
+                    ReportName = "testrest_vter1002",
                     Timezone = "GMT",
                     ReportStartTime = DateTime.ParseExact("2018-09-01T12:00:00Z", "yyyy-MM-ddTHH:mm:ssZ", CultureInfo.InvariantCulture),
                     ReportEndTime = DateTime.ParseExact("2018-09-02T12:00:00Z", "yyyy-MM-ddTHH:mm:ssZ", CultureInfo.InvariantCulture)
                 };
 
-                var reportPreferencesObj = new ReportingV3ReportSubscriptionsGet200ResponseReportPreferences()
+                var reportPreferencesObj = new Reportingv3reportsReportPreferences()
                 {
                     SignedAmounts = true,
-                    FieldNameConvention = ReportingV3ReportSubscriptionsGet200ResponseReportPreferences.FieldNameConventionEnum.SOAPI
+                    FieldNameConvention = Reportingv3reportsReportPreferences.FieldNameConventionEnum.SOAPI
                 };
 
                 requestObj.ReportPreferences = reportPreferencesObj;
@@ -40,8 +40,7 @@ namespace Cybersource_rest_samples_dotnet.Samples.Reporting.CoreServices
                 var clientConfig = new CyberSource.Client.Configuration(merchConfigDictObj: configDictionary);
                 var apiInstance = new ReportsApi(clientConfig);
 
-                var result = apiInstance.CreateReportWithHttpInfo(requestObj);
-                Console.WriteLine(result);
+                apiInstance.CreateReport(requestObj);
             }
             catch (Exception e)
             {

--- a/src/Samples/Reporting/CoreServices/CreateReportSubscriptionForReportNameByOrganization.cs
+++ b/src/Samples/Reporting/CoreServices/CreateReportSubscriptionForReportNameByOrganization.cs
@@ -12,16 +12,15 @@ namespace Cybersource_rest_samples_dotnet.Samples.Reporting.CoreServices
         {
             const string reportName = "testrest_subcription_v1";
 
-            var request = new RequestBody(ReportDefinitionName: "TransactionRequestClass",
+            var request = new RequestBody1(
+                ReportDefinitionName: "TransactionRequestClass",
+                ReportMimeType: RequestBody1.ReportMimeTypeEnum.ApplicationXml,
                 ReportFields: new List<string>() {"Request.RequestID", "Request.TransactionDate", "Request.MerchantID"},
-                ReportName: reportName)
-            {
-                ReportMimeType = RequestBody.ReportMimeTypeEnum.ApplicationXml,
-                ReportFrequency = "WEEKLY",
-                Timezone = "GMT",
-                StartTime = "0115",
-                StartDay = 1
-            };
+                ReportName: reportName,
+                ReportFrequency: RequestBody1.ReportFrequencyEnum.WEEKLY,
+                Timezone: "GMT",
+                StartTime: "0115",
+                StartDay: 1);
 
             try
             {
@@ -29,8 +28,7 @@ namespace Cybersource_rest_samples_dotnet.Samples.Reporting.CoreServices
                 var clientConfig = new CyberSource.Client.Configuration(merchConfigDictObj: configDictionary);
                 var apiInstance = new ReportSubscriptionsApi(clientConfig);
 
-                var result = apiInstance.CreateSubscriptionWithHttpInfo("", request);
-                Console.WriteLine(result);
+                apiInstance.CreateSubscription(request);
 
                 DeleteSubscriptionOfReportNameByOrganization.ReportNameToDelete = reportName;
                 DeleteSubscriptionOfReportNameByOrganization.Run();

--- a/src/Samples/Reporting/CoreServices/DeleteSubscriptionOfReportNameByOrganization.cs
+++ b/src/Samples/Reporting/CoreServices/DeleteSubscriptionOfReportNameByOrganization.cs
@@ -20,8 +20,7 @@ namespace Cybersource_rest_samples_dotnet.Samples.Reporting.CoreServices
                 var clientConfig = new CyberSource.Client.Configuration(merchConfigDictObj: configDictionary);
                 var apiInstance = new ReportSubscriptionsApi(clientConfig);
 
-                var result = apiInstance.DeleteSubscriptionWithHttpInfo(ReportNameToDelete);
-                Console.WriteLine(result);
+                apiInstance.DeleteSubscription(ReportNameToDelete);
                 ReportNameToDelete = null;
             }
             catch (Exception e)

--- a/src/Samples/Reporting/CoreServices/DownloadReport.cs
+++ b/src/Samples/Reporting/CoreServices/DownloadReport.cs
@@ -22,7 +22,7 @@ namespace Cybersource_rest_samples_dotnet.Samples.Reporting.CoreServices
 
             const string organizationId = "testrest";
             const string reportName = "testrest_v2";
-            var reportDate = "2018-09-02";
+            var reportDate = DateTime.ParseExact("2018-09-02", "yyyy-MM-dd", CultureInfo.InvariantCulture);
 
             try
             {
@@ -30,10 +30,9 @@ namespace Cybersource_rest_samples_dotnet.Samples.Reporting.CoreServices
                 var clientConfig = new CyberSource.Client.Configuration(merchConfigDictObj: configDictionary);
                 var apiInstance = new ReportDownloadsApi(clientConfig);
 
-                var result = apiInstance.DownloadReportWithHttpInfo(reportDate, reportName, organizationId);
-                Console.WriteLine(result);
+                apiInstance.DownloadReport(reportDate, reportName, organizationId);
 
-                File.WriteAllText(downloadFilePath, CreateXml(result.Data));
+                // File.WriteAllText(downloadFilePath, CreateXml(result.Data));
                 Console.WriteLine("\nFile downloaded at the below location:");
                 Console.WriteLine($"{Path.GetFullPath(downloadFilePath)}\n");
             }

--- a/src/Samples/Reporting/CoreServices/GetPurchaseAndRefundDetails.cs
+++ b/src/Samples/Reporting/CoreServices/GetPurchaseAndRefundDetails.cs
@@ -22,9 +22,8 @@ namespace Cybersource_rest_samples_dotnet.Samples.Reporting.CoreServices
                 var clientConfig = new CyberSource.Client.Configuration(merchConfigDictObj: configDictionary);
                 var apiInstance = new PurchaseAndRefundDetailsApi(clientConfig);
 
-                var result = apiInstance.GetPurchaseAndRefundDetailsWithHttpInfo(startTime, endTime, organizationId, paymentSubtype,
+                var result = apiInstance.GetPurchaseAndRefundDetails(startTime, endTime, organizationId, paymentSubtype,
                     viewBy, groupName, offset, limit);
-                Console.WriteLine(result);
             }
             catch (Exception e)
             {

--- a/src/Samples/Reporting/CoreServices/RetrieveAvailableReports.cs
+++ b/src/Samples/Reporting/CoreServices/RetrieveAvailableReports.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 using CyberSource.Api;
 
 namespace Cybersource_rest_samples_dotnet.Samples.Reporting.CoreServices
@@ -9,8 +10,8 @@ namespace Cybersource_rest_samples_dotnet.Samples.Reporting.CoreServices
         {
             try
             {
-                var startTime = "2018-10-01T00:00:00Z";
-                var endTime = "2018-10-30T23:59:59Z";
+                var startTime = DateTime.ParseExact("2018-10-01T00:00:00Z", "yyyy-MM-ddTHH:mm:ssZ", CultureInfo.InvariantCulture);
+                var endTime = DateTime.ParseExact("2018-10-30T23:59:59Z", "yyyy-MM-ddTHH:mm:ssZ", CultureInfo.InvariantCulture);
                 var timeQueryType = "executedTime";
                 var organizationId = "testrest";
 

--- a/src/Samples/SecureFileShare/CoreServices/DownloadFileWithFileIdentifier.cs
+++ b/src/Samples/SecureFileShare/CoreServices/DownloadFileWithFileIdentifier.cs
@@ -28,9 +28,9 @@ namespace Cybersource_rest_samples_dotnet.Samples.SecureFileShare.CoreServices
                 var clientConfig = new CyberSource.Client.Configuration(merchConfigDictObj: configDictionary);
                 var apiInstance = new SecureFileShareApi(clientConfig);
 
-                var result = apiInstance.GetFileWithHttpInfo(fileId, organizationId);
-                Console.WriteLine(result);
-                File.WriteAllText(downloadFilePath, CreateXml(result.Data));
+                apiInstance.GetFile(fileId, organizationId);
+                //Console.WriteLine(result);
+                //File.WriteAllText(downloadFilePath, CreateXml(result.Data));
                 Console.WriteLine("\nFile downloaded at the below location:");
                 Console.WriteLine($"{Path.GetFullPath(downloadFilePath)}\n");
             }

--- a/src/Samples/SecureFileShare/CoreServices/GetListOfFiles.cs
+++ b/src/Samples/SecureFileShare/CoreServices/GetListOfFiles.cs
@@ -10,8 +10,8 @@ namespace Cybersource_rest_samples_dotnet.Samples.SecureFileShare.CoreServices
         {
             try
             {
-                var startDate ="2018-10-20";
-                var endDate = "2018-10-30";
+                var startDate = DateTime.ParseExact("2018-10-20", "yyyy-MM-dd", CultureInfo.InvariantCulture);
+                var endDate = DateTime.ParseExact("2018-10-30", "yyyy-MM-dd", CultureInfo.InvariantCulture);
                 var organizationId = "testrest";
 
                 var configDictionary = new Configuration().GetConfiguration();

--- a/src/Samples/TMS/CoreServices/DeleteInstrumentIdentifier.cs
+++ b/src/Samples/TMS/CoreServices/DeleteInstrumentIdentifier.cs
@@ -16,8 +16,7 @@ namespace Cybersource_rest_samples_dotnet.Samples.TMS.CoreServices
                 var clientConfig = new CyberSource.Client.Configuration(merchConfigDictObj: configDictionary);
                 var apiInstance = new InstrumentIdentifierApi(clientConfig);
 
-                var result = apiInstance.TmsV1InstrumentidentifiersTokenIdDeleteWithHttpInfo(profileId, tokenId);
-                Console.WriteLine(result);
+                apiInstance.TmsV1InstrumentidentifiersTokenIdDelete(profileId, tokenId);
             }
             catch (Exception e)
             {

--- a/src/Samples/TMS/CoreServices/DeletePaymentInstrument.cs
+++ b/src/Samples/TMS/CoreServices/DeletePaymentInstrument.cs
@@ -16,8 +16,7 @@ namespace Cybersource_rest_samples_dotnet.Samples.TMS.CoreServices
                 var clientConfig = new CyberSource.Client.Configuration(merchConfigDictObj: configDictionary);
                 var apiInstance = new PaymentInstrumentsApi(clientConfig);
 
-                var result = apiInstance.TmsV1PaymentinstrumentsTokenIdDeleteWithHttpInfo(profileId, tokenId);
-                Console.WriteLine(result);
+                apiInstance.TmsV1PaymentinstrumentsTokenIdDelete(profileId, tokenId);
             }
             catch (Exception e)
             {

--- a/src/Samples/TransactionBatches/CoreServices/GetIndividualBatchFile.cs
+++ b/src/Samples/TransactionBatches/CoreServices/GetIndividualBatchFile.cs
@@ -13,9 +13,9 @@ namespace Cybersource_rest_samples_dotnet.Samples.TransactionBatches.CoreService
 
                 var configDictionary = new Configuration().GetConfiguration();
                 var clientConfig = new CyberSource.Client.Configuration(merchConfigDictObj: configDictionary);
-                var apiInstance = new TransactionBatchApi(clientConfig);
+                var apiInstance = new TransactionBatchesApi(clientConfig);
 
-                var result = apiInstance.PtsV1TransactionBatchesIdGetWithHttpInfo(id);
+                var result = apiInstance.GetTransactionBatchId(id);
                 Console.WriteLine(result);
             }
             catch (Exception e)

--- a/src/Samples/TransactionBatches/CoreServices/GetListOfBatchFiles.cs
+++ b/src/Samples/TransactionBatches/CoreServices/GetListOfBatchFiles.cs
@@ -10,14 +10,14 @@ namespace Cybersource_rest_samples_dotnet.Samples.TransactionBatches.CoreService
         {
             try
             {
-                var startTime = "2018-08-11T22:47:57Z";
-                var endTime = "2018-10-29T22:47:57Z";
+                var startTime = DateTime.ParseExact("2018-08-11T22:47:57Z", "yyyy-MM-ddTHH:mm:ssZ", CultureInfo.InvariantCulture);
+                var endTime = DateTime.ParseExact("2018-10-29T22:47:57Z", "yyyy-MM-ddTHH:mm:ssZ", CultureInfo.InvariantCulture);
 
                 var configDictionary = new Configuration().GetConfiguration();
                 var clientConfig = new CyberSource.Client.Configuration(merchConfigDictObj: configDictionary);
                 var apiInstance = new TransactionBatchesApi(clientConfig);
 
-                var result = apiInstance.PtsV1TransactionBatchesGet(startTime, endTime);
+                var result = apiInstance.GetTransactionBatches(startTime, endTime);
                 Console.WriteLine(result);
             }
             catch (Exception e)


### PR DESCRIPTION
Changes done to sample codes to make them compatible with the latest client SDK generated on 27th Feb using new spec file and updated batch files.
Changes mostly fall under the below categories:-
1. Model names and their method signatures have been updated to match with the changes in the client SDK.
2. Few Api Method calls were being done to withHttpInfo methods because of the void return type of the corresponding methods (without withHttpInfo suffix).
Now since we have the response data accessible to sample codes from the clientconfig object, calls to the methods with void return types can be made.
3. There were few parameters which were changed from Datetime? to String during the previous release to have all the sample codes in working condition.
However now those parameters have been changed back to their original Datatype which is 'Datetime?' as the query parameters are being changed from DateTime? to string inside the Api Methods.